### PR TITLE
Progress bar: render with nrql results

### DIFF
--- a/visualizations/progress-bar/index.js
+++ b/visualizations/progress-bar/index.js
@@ -139,7 +139,9 @@ const EmptyState = () => (
         returning a percentage value (0 to 100 rathern than 0 to 1). For
         example:
       </HeadingText>
-      <code>FROM EventType SELECT percentage(count(*), WHERE duration < 0.1)</code>
+      <code>
+        {'FROM EventType SELECT percentage(count(*), WHERE duration < 0.1)'}
+      </code>
     </CardBody>
   </Card>
 );


### PR DESCRIPTION
Some relevant thoughts:
* Uses color from query response
* Always rounds to nearest integer. We can consider later if we want to change what decimal place is rendered either by default or allow that to be configurable.
* Does not yet handle adding any label. What's available as a displayName value from the query by default is "Percent". An alias on the select clause can override that value. Given the default is not helpful. I'd propose we not bother for now but later when we are beyond a certain amount of the project's scope we consider something like only showing a label if an alias is provided.

<img width="1128" alt="Screen Shot 2021-05-13 at 12 35 04 PM" src="https://user-images.githubusercontent.com/3023056/118195834-ae6b0a80-b3e7-11eb-85ed-b6c90a26bd59.png">

