### PR TITLE
Create generic error state component

### DIFF
--- a/common/error-state/index.js
+++ b/common/error-state/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Card, CardBody, HeadingText } from 'nr1';
+
+const ErrorState = () => (
+  <Card className="ErrorState">
+    <CardBody className="ErrorState-cardBody">
+      <HeadingText
+        className="ErrorState-headingText"
+        spacingType={[HeadingText.SPACING_TYPE.LARGE]}
+        type={HeadingText.TYPE.HEADING_3}
+      >
+        Oops! Something went wrong.
+      </HeadingText>
+    </CardBody>
+  </Card>
+);
+
+export default ErrorState;

--- a/common/error-state/styles.scss
+++ b/common/error-state/styles.scss
@@ -1,0 +1,16 @@
+.ErrorState {
+  height: 100%;
+  text-align: center;
+}
+
+.ErrorState-cardBody {
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ErrorState-headingText {
+  color: darkgrey;
+}

--- a/visualizations/progress-bar/index.js
+++ b/visualizations/progress-bar/index.js
@@ -9,6 +9,7 @@ import {
   Spinner,
   AutoSizer,
 } from 'nr1';
+import ErrorState from '/common/error-state';
 
 export default class ProgressBarVisualization extends React.Component {
   // Custom props you wish to be configurable in the UI must also be defined in
@@ -142,20 +143,6 @@ const EmptyState = () => (
       <code>
         {'FROM EventType SELECT percentage(count(*), WHERE duration < 0.1)'}
       </code>
-    </CardBody>
-  </Card>
-);
-
-const ErrorState = () => (
-  <Card className="ErrorState">
-    <CardBody className="ErrorState-cardBody">
-      <HeadingText
-        className="ErrorState-headingText"
-        spacingType={[HeadingText.SPACING_TYPE.LARGE]}
-        type={HeadingText.TYPE.HEADING_3}
-      >
-        Oops! Something went wrong.
-      </HeadingText>
     </CardBody>
   </Card>
 );

--- a/visualizations/progress-bar/styles.scss
+++ b/visualizations/progress-bar/styles.scss
@@ -1,5 +1,6 @@
-.EmptyState,
-.ErrorState {
+@import '../../common/error-state/styles.scss';
+
+.EmptyState {
   height: 100%;
   text-align: center;
 
@@ -10,8 +11,4 @@
     flex-direction: column;
     justify-content: center;
   }
-}
-
-.ErrorState-headingText {
-  color: darkgrey;
 }


### PR DESCRIPTION
This moves what so far is duplicated ErrorState component across the three visualizations into its own shared component. The progress bar is modified here to consume the shared component. I'm leaving the other two visualizations for separate PRs because of likely merge conflicts while others are in progress there.