### PR TITLE
Jewels/range chart data transform

### DIFF
--- a/visualizations/range-chart/index.js
+++ b/visualizations/range-chart/index.js
@@ -59,7 +59,8 @@ export default class RangeChartVisualization extends React.Component {
 
         acc.tickValues.add(facetGroupName);
 
-        acc.facetGroupData[facetGroupName]
+        const isSecondSelectValue = Boolean(acc.facetGroupData[facetGroupName]);
+        isSecondSelectValue
           ? (acc.facetGroupData[facetGroupName].y = dataValue)
           : (acc.facetGroupData[facetGroupName] = {
               color: metadata?.color,


### PR DESCRIPTION
**Note**
This PR updates the VictoryChart type used because the bar chart is more appropriate for our use case. VictoryBar take a `y` & `y0` where `y0` is the base value. The VictoryErrorBar chart takes a `y` value + an `errorY` which determines the top and bottom points. Our proposed query is to have the first aggregator result in the `SELECT` statement return a numerical value that will be used for `y0` and the second aggregator result be used as the `y`

**TODO**
- [x] Need to add color to bars
- [x] Refine data transform where possible (ex: add names as separate item in reduce accumulator for tickValues to avoid re-mapping and pulling out in render)
- [ ] Quick win on bar positioning --> VictoryGroup ?


Notes:
- Larger y axis value tick labels get cutoff - will need to increase `domainPadding`