### PR TITLE
Create a shared NRQL query error component

### DIFF
--- a/common/nrql-query-error/index.js
+++ b/common/nrql-query-error/index.js
@@ -1,0 +1,1 @@
+export { default } from './nrql-query-error';

--- a/common/nrql-query-error/nrql-query-error.js
+++ b/common/nrql-query-error/nrql-query-error.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NrqlQueryError = ({ title, description }) => (
+  <div className="NrqlQueryError">
+    <div className="NrqlQueryError-title">{title}</div>
+    <div className="NrqlQueryError-description">{description}</div>
+  </div>
+);
+
+NrqlQueryError.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+    .isRequired,
+};
+
+export default NrqlQueryError;

--- a/common/nrql-query-error/styles.scss
+++ b/common/nrql-query-error/styles.scss
@@ -1,0 +1,20 @@
+.NrqlQueryError {
+  --error-red: #ff667a;
+  --external-spacing: 1rem;
+
+  border: 1px solid var(--error-red);
+  border-radius: 0.25rem;
+  height: calc(100% - 2 * var(--external-spacing));
+  box-sizing: border-box;
+  margin: var(--external-spacing);
+
+  &-title {
+    padding: 0.25rem 0.5rem;
+    color: white;
+    background: var(--error-red);
+  }
+
+  &-description {
+    padding: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Description

Creates a shared `NrqlQueryError` component that can be used to display NRQL-related errors. Mimics the chart builder styling.

## Screenshots

<img width="1919" alt="Screen Shot 2021-05-18 at 4 58 31 PM" src="https://user-images.githubusercontent.com/565661/118737922-b4ebee80-b7fa-11eb-8710-354081790fe0.png">



