### PR TITLE
Fix wrong cache key for PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-{{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
           cache-name: node-modules
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-{{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes a typo that uses the wrong cache key to repopulate `node_modules`