### PR TITLE
Remove version when running semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{ env.BOT_NAME }}
           GIT_COMMITTER_EMAIL: ${{ env.BOT_EMAIL }}
           GITHUB_TOKEN: ${{ env.BOT_TOKEN }}
-        run: npx semantic-release@15
+        run: npx semantic-release
 
       - name: Re-enable branch protection
         id: enable-branch-protection


### PR DESCRIPTION
## Description

For some reason, the release configuration is not picked up currently. Removing the version seems to fix it.
