### PR TITLE
Render NRQL syntax errors

### DIFF
--- a/src/nrql-query-error/nrql-query-error.js
+++ b/src/nrql-query-error/nrql-query-error.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const NrqlQueryError = ({ title, description }) => (
+const NrqlQueryError = ({
+  title,
+  description = 'Something went wrong with the provided NRQL query',
+}) => (
   <div className="NrqlQueryError">
     <div className="NrqlQueryError-title">{title}</div>
     <div className="NrqlQueryError-description">{description}</div>

--- a/visualizations/circular-progress-bar/index.js
+++ b/visualizations/circular-progress-bar/index.js
@@ -9,7 +9,6 @@ import {
   Spinner,
   AutoSizer,
 } from 'nr1';
-import ErrorState from '../../src/error-state';
 import NrqlQueryError from '../../src/nrql-query-error';
 import { baseLabelStyles } from '../../src/theme';
 import { getUniqueAggregatesAndFacets } from '../../src/utils/nrql-validation-helper';
@@ -130,7 +129,12 @@ export default class CircularProgressBar extends React.Component {
               }
 
               if (error) {
-                return <ErrorState />;
+                return (
+                  <NrqlQueryError
+                    title="NRQL Syntax Error"
+                    description={error.message}
+                  />
+                );
               }
 
               if (!this.nrqlInputIsValid(data)) {

--- a/visualizations/range-chart/index.js
+++ b/visualizations/range-chart/index.js
@@ -112,7 +112,12 @@ export default class RangeChartVisualization extends React.Component {
               }
 
               if (error) {
-                return <ErrorState />;
+                return (
+                  <NrqlQueryError
+                    title="NRQL Syntax Error"
+                    description={error.message}
+                  />
+                );
               }
 
               if (!this.nrqlInputIsValid(data)) {

--- a/visualizations/stacked-bar-chart/index.js
+++ b/visualizations/stacked-bar-chart/index.js
@@ -17,7 +17,6 @@ import {
   VictoryTooltip,
 } from 'victory';
 
-import ErrorState from '../../src/error-state';
 import Legend from '../../src/legend';
 import NrqlQueryError from '../../src/nrql-query-error';
 
@@ -167,7 +166,12 @@ export default class StackedBarChart extends React.Component {
               }
 
               if (error) {
-                return <ErrorState />;
+                return (
+                  <NrqlQueryError
+                    title="NRQL Syntax Error"
+                    description={error.message}
+                  />
+                );
               }
 
               if (!this.nrqlInputIsValid(data)) {


### PR DESCRIPTION
This PR uses the `NrqlQueryError` component when the `NrqlQuery` component returns an error. `error.message` matches what the QueryBuilder shows to the user on a syntax error. 


<img width="1082" alt="Circular-nrql-syntax" src="https://user-images.githubusercontent.com/12112563/119209305-c2071880-ba5a-11eb-97ea-8456bd0e80e5.png">
<img width="1083" alt="Range chart nrql syntax" src="https://user-images.githubusercontent.com/12112563/119209306-c3384580-ba5a-11eb-8726-e023c92fa2d2.png">
<img width="1091" alt="stacked bar syntax error" src="https://user-images.githubusercontent.com/12112563/119209307-c3d0dc00-ba5a-11eb-8596-3dded55be73e.png">
