### PR TITLE
Uses correct input argument naming for formatTicks in RangeChart

### DIFF
--- a/visualizations/range-chart/index.js
+++ b/visualizations/range-chart/index.js
@@ -150,7 +150,7 @@ export default class RangeChartVisualization extends React.Component {
                     />
                     <VictoryAxis
                       dependentAxis
-                      tickFormat={(t) => formatTicks({ unitType, t })}
+                      tickFormat={(tick) => formatTicks({ unitType, tick })}
                     />
                     <VictoryBar
                       barWidth={barWidth}


### PR DESCRIPTION
This PR fixes a regression where we were passing `t` to `formatTicks` but it accepts an object with the key `tick`. This was causing "undefined" for the y axis ticks in the range chart.

Before fix:
<img width="694" alt="Custom_visualizations_builder___New_Relic_One" src="https://user-images.githubusercontent.com/12112563/119210109-6723f000-ba5f-11eb-8e9d-a7f732de6f5c.png">

After fix:
<img width="655" alt="Custom_visualizations_builder___New_Relic_One" src="https://user-images.githubusercontent.com/12112563/119210092-4c517b80-ba5f-11eb-9681-17cde03a3d46.png">
