### PR TITLE
Explicitly checkout main branch on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Release
 
 on:
   push:
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v1
@@ -53,6 +55,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
+          ref: main
           fetch-depth: 2
 
       - name: Setup Node.js
@@ -158,6 +161,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
By default, the `actions/checkout` action will check out the SHA that triggered the workflow. When releasing, this references the merge commit. This causes issues with the 3rd party notices and conventional commits workflows since new commits are pushed because of them.

This PR explicitly checks out the `main` branch to ensure it is working with everything pushed up to remote.