### PR TITLE
Robert/text fixes

### DIFF
--- a/catalog/documentation.md
+++ b/catalog/documentation.md
@@ -1,4 +1,4 @@
-# Victory charts visualizations
+# Victory Charts Visualizations
 Visualize your New Relic data with Victory charts!
 
 1. [Add this Nerdpack to your account](https://developer.newrelic.com/build-apps/publish-deploy/subscribe/)

--- a/catalog/documentation.md
+++ b/catalog/documentation.md
@@ -29,8 +29,8 @@ To use the visualization, provide the following properties:
 | `accountId`   | Associated account ID for the data you wish to plot. | Yes     |
 | `other.visible`   | A toggle that controls the display of "other" groups of attributes | No     |
 | `yAxis.label`   | A custom label to describe the y-axis | No     |
-| `yAxis.max`   | Maximum domain value for y axis | No     |
-| `yAxis.min`   | Minimum domain value for y axis | No     |
+| `yAxis.max`   | Maximum domain value for y-axis | No     |
+| `yAxis.min`   | Minimum domain value for y-axis | No     |
 
 
 ### Stacked bar chart NRQL Data Details
@@ -47,9 +47,9 @@ You must select an attribute that's either numeric or an aggregate function. You
 
 | NRQL feature   | Usage      | Type |
 | -------------- | ----------- | ----------- |
-| All but last facet attribute     | X axis label or bar on bar chart      | `string` or `boolean`     |
+| All but last facet attribute     | X-axis label or bar on bar chart      | `string` or `boolean`     |
 | Last facet attribute   | Bar color or segment of bar on bar chart       | `string` or `boolean`       |
-| Aggregate    | Y axis value or bar height       | aggregate function    |
+| Aggregate    | Y-axis value or bar height       | aggregate function    |
 
 #### Example NRQL Queries
 
@@ -103,9 +103,9 @@ You must supply two aggregate functions to act as the top and bottom of the rang
 
 | NRQL feature   | Usage      | Type |
 | -------------- | ----------- | ----------- |
-| First aggregate     | Y axis position of top of range bar      | aggregate function     |
-| Second aggregate   | Y axis position of bottom of range bar       | aggregate function       |
-| Facet     | X axis position or x axis label   | `string` or `boolean`      |
+| First aggregate     | Y-axis position of top of range bar      | aggregate function     |
+| Second aggregate   | Y-axis position of bottom of range bar       | aggregate function       |
+| Facet     | X-axis position or x-axis label   | `string` or `boolean`      |
 
 #### Example NRQL Queries
 

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
   "id": "cf5f13d9-815f-4907-a21d-83d02fa2a4fb",
-  "displayName": "Victory charts visualizations",
+  "displayName": "Victory Charts Visualizations",
   "description": "Visualizations built on top of Victory charts"
 }

--- a/visualizations/stacked-bar-chart/index.js
+++ b/visualizations/stacked-bar-chart/index.js
@@ -95,12 +95,12 @@ export default class StackedBarChart extends React.Component {
    * Transforms NrqlQuery output to a form easy to pass to a set of VictoryBar
    * components.
    *
-   * Uses `metdata.color` for the bar fill colors.
+   * Uses `metadata.color` for the bar fill colors.
    *
-   * Builds labels for bars and bar segements using the `value` property on
+   * Builds labels for bars and bar segments using the `value` property on
    * `metadata.groups` entries where `type` === "facet".
    *
-   * Uses the `y` property on the data array entry for y axis values.
+   * Uses the `y` property on the data array entry for y-axis values.
    *
    * @param {{data: {y}[], metadata: { color: string, groups: {type: string, value: string}[]} }[]} rawData
    * @returns {{x: string, y: number, color: string, segmentLabel: string}[][]}

--- a/visualizations/stacked-bar-chart/nr1.json
+++ b/visualizations/stacked-bar-chart/nr1.json
@@ -25,13 +25,13 @@
     }, 
     {
       "name": "yAxis",
-      "title": "Y axis configuration",
+      "title": "Y-axis configuration",
       "type": "namespace",
       "items": [
         {
           "name": "label",
           "title": "Label",
-          "description": "Custom label for y axis",
+          "description": "Custom label for y-axis",
           "type": "string"
         }
       ]


### PR DESCRIPTION
Minor typos and text standardizing
- Ensure we're consistent with hyphens for x-axis and y-axis ([style guide ref](https://www.chicagomanualofstyle.org/qanda/data/faq/topics/HyphensEnDashesEmDashes/faq0138.html))
- Uses title case for nerdpack display name since all other global nerdpacks use title casing (runs a bit counter to my understanding from [this thread](https://newrelic.slack.com/archives/G01GR8SHEHW/p1619567165145100), but clearly it should be title cased)

![image](https://user-images.githubusercontent.com/20293876/119551253-45bc5000-bd4e-11eb-90a8-f91d01c7ac8e.png)
