### PR TITLE
Handle empty data returns in stacked bar chart

### DIFF
--- a/visualizations/stacked-bar-chart/index.js
+++ b/visualizations/stacked-bar-chart/index.js
@@ -110,8 +110,7 @@ export default class StackedBarChart extends React.Component {
       return [
         [
           {
-            segmentLabel: 'No data',
-            x: 'null',
+            x: 'No chart data available',
             y: 0,
           },
         ],

--- a/visualizations/stacked-bar-chart/index.js
+++ b/visualizations/stacked-bar-chart/index.js
@@ -111,7 +111,6 @@ export default class StackedBarChart extends React.Component {
         [
           {
             x: 'No chart data available',
-            y: 0,
           },
         ],
       ];

--- a/visualizations/stacked-bar-chart/index.js
+++ b/visualizations/stacked-bar-chart/index.js
@@ -106,6 +106,18 @@ export default class StackedBarChart extends React.Component {
    * @returns {{x: string, y: number, color: string, segmentLabel: string}[][]}
    */
   transformData = (rawData) => {
+    if (rawData.length === 0) {
+      return [
+        [
+          {
+            segmentLabel: 'No data',
+            x: 'null',
+            y: 0,
+          },
+        ],
+      ];
+    }
+
     const colorsBySegmentLabel = new Map();
 
     // Gather values for each bar data series.
@@ -183,15 +195,17 @@ export default class StackedBarChart extends React.Component {
     const { yAxis } = this.props;
 
     // `unitType` is a value to map NRQL data with units
-    const unitType = data[0].metadata.units_data.y;
+    const unitType = data[0]?.metadata.units_data.y;
 
     // use label given in config or use display name of aggregate for y-axis
     const label =
-      yAxis.label ||
-      `${
-        data[0].metadata.groups.find(({ type }) => type === 'function')
-          .displayName
-      }${typeToUnit(unitType)}`;
+      data.length === 0
+        ? ''
+        : yAxis.label ||
+          `${
+            data[0]?.metadata.groups.find(({ type }) => type === 'function')
+              .displayName
+          }${typeToUnit(unitType)}`;
 
     // find the increment of ticks to determine decimal formatting
     const yDomainValues = transformedData.map(([{ y }]) => y);
@@ -204,11 +218,13 @@ export default class StackedBarChart extends React.Component {
       label,
       tickCount,
       tickFormat: (tick) =>
-        formatNumberTicks({
-          unitType,
-          tick,
-          tickIncrement,
-        }),
+        data.length === 0
+          ? () => ''
+          : formatNumberTicks({
+              unitType,
+              tick,
+              tickIncrement,
+            }),
     };
   };
 
@@ -247,7 +263,7 @@ export default class StackedBarChart extends React.Component {
                 );
               }
 
-              if (!this.nrqlInputIsValid(data)) {
+              if (!this.nrqlInputIsValid(data) && data.length !== 0) {
                 return (
                   <NrqlQueryError
                     title="Unsupported NRQL query"


### PR DESCRIPTION
### Problem to address
- Empty data returns from the `NrqlQuery` (data = `[]`) are being caught in `nrqlInputIsValid` and being flagged, inaccurately, as unsupported query types. See screenshot:

![Screen Shot 2021-05-27 at 11 15 46 AM](https://user-images.githubusercontent.com/20293876/119876656-f7898700-bedc-11eb-9417-20d80b6691a3.jpg)

### Solution
This PR addresses this bug by handling empty data returns:
- Allow empty data returns to bypass transform logic
- Add defensive optional chaining 
- Render a chart with nothing in it and the same text that Query Builder provides

![Screen Shot 2021-05-27 at 11 11 09 AM](https://user-images.githubusercontent.com/20293876/119876891-3ae3f580-bedd-11eb-803e-c81638d840c2.jpg)

### To test:
- https://staging.one.nr/0EPwJz50Ow7 

Jira: https://newrelic.atlassian.net/browse/DEVEX-1804
