### PR TITLE
Add security policy note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,10 @@ Keep in mind that when you submit your pull request, you'll need to sign the CLA
 via the click-through using CLA-Assistant. If you'd like to execute our
 corporate CLA, or if you have any questions, please drop us an email at
 opensource+nr1-victory-visualizations@newrelic.com.
+
+**A note about vulnerabilities**
+
+As noted in our [security policy](../../security/policy), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
+
+If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
+


### PR DESCRIPTION
This `README` addition should address https://github.com/newrelic/nr1-victory-visualizations/issues/2

The text is copied from the suggested source: https://github.com/newrelic/open-by-default#contribute