### PR TITLE
Add toggle for visibility of Other entry in scatter plot visualization

### DIFF
--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -47,9 +47,20 @@ export default class ScatterPlotChartVisualization extends React.Component {
         query: PropTypes.string,
       })
     ),
+
+    /**
+     * Object with a singular boolean value.
+     * Determines if "other" attributes are included in visualization.
+     */
+    other: PropTypes.shape({
+      visible: PropTypes.bool,
+    }),
   };
 
   getAggregatesData = (rawData, functionDisplayNames) => {
+    const {
+      other: { visible: showOther },
+    } = this.props;
     const queryHasZField = functionDisplayNames.length > 2;
 
     // `rawData` contains an entry per combo of aggregate function and facet. Here
@@ -57,6 +68,10 @@ export default class ScatterPlotChartVisualization extends React.Component {
     // all of the facet's aggregate function values.
     const facetGroupData = rawData.reduce((acc, { data, metadata }) => {
       const facetGroupName = getFacetLabel(metadata?.groups);
+      if (!showOther && facetGroupName === 'Other') {
+        return acc;
+      }
+
       const dataValue = data?.[0]?.y;
       const unitType = metadata?.units_data?.y;
       const aggregateFunction = metadata?.groups.filter(

--- a/visualizations/scatter-plot-chart/nr1.json
+++ b/visualizations/scatter-plot-chart/nr1.json
@@ -22,6 +22,19 @@
           "type": "nrql"
         }
       ]
+    },
+    {
+      "name": "other",
+      "title": "Other groups",
+      "type": "namespace",
+      "items": [
+        {
+          "name": "visible",
+          "title": "Visible",
+          "description": "Manages the visibility of \"Other\" groups of attributes",
+          "type": "boolean"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds a toggle for visibility of the Other entry in the scatter plot visualization. It defaults to the visibility turned off. 

This makes a big difference for the scatter plot, especially when one of the axis values or the size value is a count and the Other entry sums up way more events than any of the other entries.

For example, here the toggle is on and you see the Other entry as an outlier that causing the entries we are likely more interested in being flattened on the y-axis.
<img width="965" alt="Screen Shot 2021-07-22 at 9 47 15 AM" src="https://user-images.githubusercontent.com/3023056/126701700-0362d0c3-d1cc-4daa-8228-601ad0c87058.png">


And below we can actually digest the y-axis values after toggling the visibility of the Other entry off.
<img width="948" alt="Screen Shot 2021-07-22 at 9 47 24 AM" src="https://user-images.githubusercontent.com/3023056/126701710-3e2bdcde-e8ff-4807-a7f1-657536b160c8.png">

