### PR TITLE
fix(ScatterPlot): Fix y-axis unit label, fix x-axis tick count

### DIFF
--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -185,27 +185,18 @@ export default class ScatterPlotChartVisualization extends React.Component {
   getXAxisLabelProps = (data, transformedData, height) => {
     const { uniqueAggregates } = getUniqueAggregatesAndFacets(data);
     const { uniqueNonAggregates } = getUniqueNonAggregates(data);
-    const uniqueAttributeNames = Array.from(uniqueNonAggregates);
-    const uniqueAggregatesNames = Array.from(uniqueAggregates);
+    const xDisplayName = transformedData[0]?.xDisplayName;
+    const unitType = transformedData[0]?.xUnitType || 'UNKNOWN';
+    const label = `${xDisplayName}${typeToUnit(unitType)}`;
 
-    // `unitType` is a value to map NRQL data with units -- only works with aggregate queries
-    const unitType = data[0].metadata.units_data.y
-      ? data[0].metadata.units_data.y
-      : 'UNKNOWN';
-
-    let label;
     let xDomainValues;
-
     if (uniqueAggregates.size > 1) {
-      label = `${uniqueAggregatesNames[0]}${typeToUnit(unitType)}`;
-
       xDomainValues = transformedData
         .filter((datapoint) => {
-          return datapoint.xDisplayName === uniqueAggregatesNames[0];
+          return datapoint.xDisplayName === xDisplayName;
         })
         .map(({ x }) => x);
     } else if (uniqueNonAggregates.size > 1) {
-      label = `${uniqueAttributeNames[0]}${typeToUnit(unitType)}`;
       xDomainValues = transformedData.map((point) => point.x);
     }
 
@@ -230,25 +221,18 @@ export default class ScatterPlotChartVisualization extends React.Component {
   getYAxisLabelProps = (data, transformedData, height) => {
     const { uniqueAggregates } = getUniqueAggregatesAndFacets(data);
     const { uniqueNonAggregates } = getUniqueNonAggregates(data);
-    const uniqueAttributeNames = Array.from(uniqueNonAggregates);
-    const uniqueAggregatesNames = Array.from(uniqueAggregates);
-    // `unitType` is a value to map NRQL data with units
-    const unitType = data[0].metadata.units_data.y
-      ? data[0].metadata.units_data.y
-      : 'UNKNOWN';
-    let label;
+    const yDisplayName = transformedData[0]?.yDisplayName;
+    const unitType = transformedData[0]?.yUnitType || 'UNKNOWN';
+    const label = `${yDisplayName}${typeToUnit(unitType)}`;
+
     let yDomainValues;
-
     if (uniqueAggregates.size > 1) {
-      label = `${uniqueAggregatesNames[1]}${typeToUnit(unitType)}`;
-
       yDomainValues = transformedData
         .filter((datapoint) => {
-          return datapoint.yDisplayName === uniqueAggregatesNames[1];
+          return datapoint.yDisplayName === yDisplayName;
         })
         .map(({ y }) => y);
     } else if (uniqueNonAggregates.size > 1) {
-      label = `${uniqueAttributeNames[1]}${typeToUnit(unitType)}`;
       yDomainValues = transformedData.map((point) => point.y);
     }
 

--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -209,7 +209,7 @@ export default class ScatterPlotChartVisualization extends React.Component {
 
   getAxisLabelProps = ({ displayName, unitType, min, max, tickCount }) => {
     return {
-      label: `${displayName}${typeToUnit(unitType)}`,
+      label: `${displayName}${typeToUnit(unitType || 'UNKNOWN')}`,
       tickCount,
       tickFormat: (tick) =>
         formatNumberTicks({
@@ -218,26 +218,6 @@ export default class ScatterPlotChartVisualization extends React.Component {
           tickIncrement: (max - min) / tickCount,
         }),
     };
-  };
-
-  getXAxisLabelProps = ({ series, xMin, xMax, xTickCount }) => {
-    return this.getAxisLabelProps({
-      displayName: series[0]?.xDisplayName,
-      unitType: series[0]?.xUnitType || 'UNKNOWN',
-      min: xMin,
-      max: xMax,
-      tickCount: xTickCount,
-    });
-  };
-
-  getYAxisLabelProps = ({ series, yMin, yMax, yTickCount }) => {
-    return this.getAxisLabelProps({
-      displayName: series[0]?.yDisplayName,
-      unitType: series[0]?.yUnitType || 'UNKNOWN',
-      min: yMin,
-      max: yMax,
-      tickCount: yTickCount,
-    });
   };
 
   tooltipLabel = ({ datum }) => {
@@ -325,19 +305,22 @@ export default class ScatterPlotChartVisualization extends React.Component {
               const legendHeight = 50;
               const spaceBelowLegend = 16;
 
-              const xAxisLabelProps = this.getXAxisLabelProps({
-                series,
-                xMin: range.xMin,
-                xMax: range.xMax,
-                xTickCount: Math.round(
+              const xAxisLabelProps = this.getAxisLabelProps({
+                displayName: series[0]?.xDisplayName,
+                unitType: series[0]?.xUnitType,
+                min: range.xMin,
+                max: range.xMax,
+                tickCount: Math.round(
                   (width - chartLeftPadding - chartRightPadding) / 100
                 ),
               });
-              const yAxisLabelProps = this.getYAxisLabelProps({
-                series,
-                yMin: range.yMin,
-                yMax: range.yMax,
-                yTickCount: Math.round((height - legendHeight) / 70),
+
+              const yAxisLabelProps = this.getAxisLabelProps({
+                displayName: series[0]?.yDisplayName,
+                unitType: series[0]?.yUnitType,
+                min: range.yMin,
+                max: range.yMax,
+                tickCount: Math.round((height - legendHeight) / 70),
               });
 
               return (

--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -220,23 +220,23 @@ export default class ScatterPlotChartVisualization extends React.Component {
     };
   };
 
-  getXAxisLabelProps = ({ series, xMin, xMax, tickCount }) => {
+  getXAxisLabelProps = ({ series, xMin, xMax, xTickCount }) => {
     return this.getAxisLabelProps({
       displayName: series[0]?.xDisplayName,
       unitType: series[0]?.xUnitType || 'UNKNOWN',
       min: xMin,
       max: xMax,
-      tickCount,
+      tickCount: xTickCount,
     });
   };
 
-  getYAxisLabelProps = ({ series, yMin, yMax, tickCount }) => {
+  getYAxisLabelProps = ({ series, yMin, yMax, yTickCount }) => {
     return this.getAxisLabelProps({
       displayName: series[0]?.yDisplayName,
       unitType: series[0]?.yUnitType || 'UNKNOWN',
       min: yMin,
       max: yMax,
-      tickCount,
+      tickCount: yTickCount,
     });
   };
 
@@ -329,7 +329,7 @@ export default class ScatterPlotChartVisualization extends React.Component {
                 series,
                 xMin: range.xMin,
                 xMax: range.xMax,
-                tickCount: Math.round(
+                xTickCount: Math.round(
                   (width - chartLeftPadding - chartRightPadding) / 100
                 ),
               });
@@ -337,7 +337,7 @@ export default class ScatterPlotChartVisualization extends React.Component {
                 series,
                 yMin: range.yMin,
                 yMax: range.yMax,
-                tickCount: Math.round((height - legendHeight) / 70),
+                yTickCount: Math.round((height - legendHeight) / 70),
               });
 
               return (

--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -207,15 +207,11 @@ export default class ScatterPlotChartVisualization extends React.Component {
     return uniqueAggregates.size >= 2 || uniqueNonAggregates.size >= 2;
   };
 
-  getXAxisLabelProps = (transformedData, xMin, xMax, height) => {
+  getXAxisLabelProps = (transformedData, xMin, xMax, tickCount) => {
     const displayName = transformedData[0]?.xDisplayName;
     const unitType = transformedData[0]?.xUnitType || 'UNKNOWN';
     const label = `${displayName}${typeToUnit(unitType)}`;
 
-    // Find the increment of ticks to determine decimal formatting
-    const tickCount = Math.round((height - 50) / 70);
-    const tickIncrement = (xMax - xMin) / tickCount;
-
     return {
       label,
       tickCount,
@@ -223,19 +219,15 @@ export default class ScatterPlotChartVisualization extends React.Component {
         formatNumberTicks({
           unitType,
           tick,
-          tickIncrement,
+          tickIncrement: (xMax - xMin) / tickCount,
         }),
     };
   };
 
-  getYAxisLabelProps = (transformedData, yMin, yMax, height) => {
+  getYAxisLabelProps = (transformedData, yMin, yMax, tickCount) => {
     const displayName = transformedData[0]?.yDisplayName;
     const unitType = transformedData[0]?.yUnitType || 'UNKNOWN';
     const label = `${displayName}${typeToUnit(unitType)}`;
-
-    // Find the increment of ticks to determine decimal formatting
-    const tickCount = Math.round((height - 50) / 70);
-    const tickIncrement = (yMax - yMin) / tickCount;
 
     return {
       label,
@@ -244,7 +236,7 @@ export default class ScatterPlotChartVisualization extends React.Component {
         formatNumberTicks({
           unitType,
           tick,
-          tickIncrement,
+          tickIncrement: (yMax - yMin) / tickCount,
         }),
     };
   };
@@ -331,23 +323,24 @@ export default class ScatterPlotChartVisualization extends React.Component {
               const chartRightPadding = 25;
               const legendHeight = 50;
               const spaceBelowLegend = 16;
+              const yDomainWidth = 50; // represents the maximum width of the ticks for y-axis
+              const yAxisPadding = 16;
+              const xTickCount = Math.round(
+                (width - chartLeftPadding - chartRightPadding) / 70
+              );
+              const yTickCount = Math.round((height - legendHeight) / 70);
 
               const xAxisLabelProps = this.getXAxisLabelProps(
                 series,
                 range.xMin,
                 range.xMax,
-                height
+                xTickCount
               );
-
-              // `yDomainWidth` represents the maximum width of the ticks for y-axis
-              const yDomainWidth = 50;
-              const yAxisPadding = 16;
-
               const yAxisLabelProps = this.getYAxisLabelProps(
                 series,
                 range.yMin,
                 range.yMax,
-                height
+                yTickCount
               );
 
               return (

--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -207,38 +207,37 @@ export default class ScatterPlotChartVisualization extends React.Component {
     return uniqueAggregates.size >= 2 || uniqueNonAggregates.size >= 2;
   };
 
-  getXAxisLabelProps = (transformedData, xMin, xMax, tickCount) => {
-    const displayName = transformedData[0]?.xDisplayName;
-    const unitType = transformedData[0]?.xUnitType || 'UNKNOWN';
-    const label = `${displayName}${typeToUnit(unitType)}`;
-
+  getAxisLabelProps = ({ displayName, unitType, min, max, tickCount }) => {
     return {
-      label,
+      label: `${displayName}${typeToUnit(unitType)}`,
       tickCount,
       tickFormat: (tick) =>
         formatNumberTicks({
           unitType,
           tick,
-          tickIncrement: (xMax - xMin) / tickCount,
+          tickIncrement: (max - min) / tickCount,
         }),
     };
   };
 
-  getYAxisLabelProps = (transformedData, yMin, yMax, tickCount) => {
-    const displayName = transformedData[0]?.yDisplayName;
-    const unitType = transformedData[0]?.yUnitType || 'UNKNOWN';
-    const label = `${displayName}${typeToUnit(unitType)}`;
-
-    return {
-      label,
+  getXAxisLabelProps = ({ series, xMin, xMax, tickCount }) => {
+    return this.getAxisLabelProps({
+      displayName: series[0]?.xDisplayName,
+      unitType: series[0]?.xUnitType || 'UNKNOWN',
+      min: xMin,
+      max: xMax,
       tickCount,
-      tickFormat: (tick) =>
-        formatNumberTicks({
-          unitType,
-          tick,
-          tickIncrement: (yMax - yMin) / tickCount,
-        }),
-    };
+    });
+  };
+
+  getYAxisLabelProps = ({ series, yMin, yMax, tickCount }) => {
+    return this.getAxisLabelProps({
+      displayName: series[0]?.yDisplayName,
+      unitType: series[0]?.yUnitType || 'UNKNOWN',
+      min: yMin,
+      max: yMax,
+      tickCount,
+    });
   };
 
   tooltipLabel = ({ datum }) => {
@@ -325,23 +324,21 @@ export default class ScatterPlotChartVisualization extends React.Component {
               const spaceBelowLegend = 16;
               const yDomainWidth = 50; // represents the maximum width of the ticks for y-axis
               const yAxisPadding = 16;
-              const xTickCount = Math.round(
-                (width - chartLeftPadding - chartRightPadding) / 70
-              );
-              const yTickCount = Math.round((height - legendHeight) / 70);
 
-              const xAxisLabelProps = this.getXAxisLabelProps(
+              const xAxisLabelProps = this.getXAxisLabelProps({
                 series,
-                range.xMin,
-                range.xMax,
-                xTickCount
-              );
-              const yAxisLabelProps = this.getYAxisLabelProps(
+                xMin: range.xMin,
+                xMax: range.xMax,
+                xTickCount: Math.round(
+                  (width - chartLeftPadding - chartRightPadding) / 70
+                ),
+              });
+              const yAxisLabelProps = this.getYAxisLabelProps({
                 series,
-                range.yMin,
-                range.yMax,
-                yTickCount
-              );
+                yMin: range.yMin,
+                yMax: range.yMax,
+                yTickCount: Math.round((height - legendHeight) / 70),
+              });
 
               return (
                 <>

--- a/visualizations/scatter-plot-chart/index.js
+++ b/visualizations/scatter-plot-chart/index.js
@@ -318,26 +318,26 @@ export default class ScatterPlotChartVisualization extends React.Component {
                 return acc;
               }, []);
 
-              const chartLeftPadding = 100;
+              const yTickLabelWidth = 45;
+              const yAxisPadding = 16;
+              const chartLeftPadding = yTickLabelWidth + yAxisPadding + 25;
               const chartRightPadding = 25;
               const legendHeight = 50;
               const spaceBelowLegend = 16;
-              const yDomainWidth = 50; // represents the maximum width of the ticks for y-axis
-              const yAxisPadding = 16;
 
               const xAxisLabelProps = this.getXAxisLabelProps({
                 series,
                 xMin: range.xMin,
                 xMax: range.xMax,
-                xTickCount: Math.round(
-                  (width - chartLeftPadding - chartRightPadding) / 70
+                tickCount: Math.round(
+                  (width - chartLeftPadding - chartRightPadding) / 100
                 ),
               });
               const yAxisLabelProps = this.getYAxisLabelProps({
                 series,
                 yMin: range.yMin,
                 yMax: range.yMax,
-                yTickCount: Math.round((height - legendHeight) / 70),
+                tickCount: Math.round((height - legendHeight) / 70),
               });
 
               return (
@@ -364,7 +364,7 @@ export default class ScatterPlotChartVisualization extends React.Component {
                       {...yAxisLabelProps}
                       dependentAxis
                       style={{
-                        axisLabel: { padding: yDomainWidth + yAxisPadding },
+                        axisLabel: { padding: yTickLabelWidth + yAxisPadding },
                       }}
                     />
                     <VictoryScatter


### PR DESCRIPTION
### 1. Fixes y-axis unit label
The y-axis unit label was being set to the unit type of the x-axis.

To reproduce the problem, use the following query and notice the y-axis unit is a percentage when only the x-axis label should be a percentage: `FROM Transaction SELECT percentage(count(*), WHERE duration > 1), average(databaseDuration) LIMIT 500 facet appName`

### 2. Fixes x-axis tick count
The ticks and their labels on the x-axis were overlapping at smaller width because the x-axis tick count was being calculated using vertical values (height, legend height) rather than corresponding x-axis values.

To reproduce the problem, use the same query above and make the width of the chart small while keeping the height taller.

### 3. Reduces wasted width space
There was more white space than needed on the left of the chart and around the y-axis unit label.


# Before
<img width="644" alt="Screen Shot 2021-07-27 at 11 16 28 AM" src="https://user-images.githubusercontent.com/3023056/127229486-2364c19e-56e1-4501-8a64-086f4bb4029c.png">

# After
<img width="679" alt="Screen Shot 2021-07-27 at 11 23 54 AM" src="https://user-images.githubusercontent.com/3023056/127229575-0b7d80b7-fcfd-4dd1-ae3a-5e97b1a234b3.png">

